### PR TITLE
Define RI and API as scope of provided

### DIFF
--- a/exchange-rate/pom.xml
+++ b/exchange-rate/pom.xml
@@ -25,6 +25,7 @@
             <groupId>org.javamoney</groupId>
             <artifactId>moneta</artifactId>
             <version>1.0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,11 +122,13 @@
             <groupId>javax.money</groupId>
             <artifactId>money-api</artifactId>
             <version>${jsr.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.javamoney</groupId>
             <artifactId>moneta</artifactId>
             <version>${jsr.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Once the lib shouldn't define which RI version will be used, the best strategy is define the RI and API on lib as provided scope.