### PR TITLE
Add --batch-mode to Maven commands in CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ jdk:
   - oraclejdk9
 
 after_success:
-  - mvn deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml
-  - mvn jacoco:report coveralls:jacoco -DsourceEncoding=UTF-8
+  - mvn --batch-mode deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml
+  - mvn --batch-mode jacoco:report coveralls:jacoco -DsourceEncoding=UTF-8


### PR DESCRIPTION
--batch-mode is more convenient for CI services since it avoids
unnecessary expansion of the build output.